### PR TITLE
make gzipped streaming work in chrome

### DIFF
--- a/test/streamsource.js
+++ b/test/streamsource.js
@@ -147,7 +147,9 @@ function startServer( port, grunt ) {
          serverResponse.setHeader("content-encoding", 'gzip');
          serverResponse.writeHead(200);      
          
-         clientResponse.pipe(zlib.createGzip()).pipe(serverResponse);
+         clientResponse.pipe(zlib.createGzip({
+            flush: zlib.Z_SYNC_FLUSH
+         })).pipe(serverResponse);
          
        });
    }   


### PR DESCRIPTION
i think this is only needed because each chunk is small it doesn't get flushed. i'm just guessing, though.
