### PR TITLE
Add support for jam package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,10 @@
   },
   "dependencies": {
     "clarinet": "~0.8.0"
+  },
+  "jam": {
+    "main": "dist/oboe-browser.js",
+    "include":["dist/oboe-browser.js", "LICENCE", "package.json", "README.md"],
+    "dependencies": {}
   }
 }


### PR DESCRIPTION
Hi there, I added support for the jam package manager. Very small change, just mainly to tell jam to use the dist file.

I also published oboe to jam, available here:

http://jamjs.org/packages/#/details/oboe

If you want to manage it, just create an account, and I will pass the reigns over! Thanks!
