### PR TITLE
fix https support in node regexp

### DIFF
--- a/src/streamingHttp.node.js
+++ b/src/streamingHttp.node.js
@@ -53,7 +53,7 @@ function streamingHttp(oboeBus, http, method, contentSource, data, headers) {
    }
    
    function fetchHttpUrl( url ) {
-      if( !contentSource.match(/http:\/\//) ) {
+      if( !contentSource.match(/https?:\/\//) ) {
          contentSource = 'http://' + contentSource;
       }                           
                            


### PR DESCRIPTION
no double prefix, even though browser auto-correct it 

(it showed up in my NoScript when I browserified the node version)
