### PR TITLE
issue #40: add http.IncomingMessage stream detection

### DIFF
--- a/dist/oboe-node.js
+++ b/dist/oboe-node.js
@@ -2411,7 +2411,7 @@ function applyDefaults( passthrough, url, httpMethodName, body, headers, withCre
 function oboe(arg1, arg2) {
 
    if( arg1 ) {
-      if (arg1.url && !(arg1 instanceof require('http').IncomingMessage)) {
+      if (arg1.url && !(arg1 instanceof require('stream').Readable)) {
    
          // method signature is:
          //    oboe({method:m, url:u, body:b, headers:{...}})

--- a/dist/oboe-node.js
+++ b/dist/oboe-node.js
@@ -2411,7 +2411,7 @@ function applyDefaults( passthrough, url, httpMethodName, body, headers, withCre
 function oboe(arg1, arg2) {
 
    if( arg1 ) {
-      if (arg1.url) {
+      if (arg1.url && !(arg1 instanceof require('http').IncomingMessage)) {
    
          // method signature is:
          //    oboe({method:m, url:u, body:b, headers:{...}})


### PR DESCRIPTION
To overcome the problem of issue #40, I change a single line of oboe() instantiation to check if arg1 is an instance of stream.Readable. If it is true, it will be treated stream-like.
