### PR TITLE
Browserify support

### DIFF
--- a/dist/oboe-browser.js
+++ b/dist/oboe-browser.js
@@ -2567,6 +2567,8 @@ function oboe(arg1) {
 
    if ( typeof define === "function" && define.amd ) {
       define( "oboe", [], function () { return oboe; } );
+   } else if (typeof exports === 'object') {
+      module.exports = oboe;
    } else {
       window.oboe = oboe;
    }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.15.1",
   "description": "Oboe.js reads json, giving you the objects as they are found without waiting for the stream to finish",
   "main": "./dist/oboe-node.js",
+  "browser": "./dist/oboe-browser.js",
   "scripts": {
     "test": "node ./node_modules/grunt-cli/bin/grunt headless-mode default",
     "test-start-server": "node ./node_modules/grunt-cli/bin/grunt test-start-server",

--- a/src/wrapper.browser.js
+++ b/src/wrapper.browser.js
@@ -8,6 +8,8 @@
 
    if ( typeof define === "function" && define.amd ) {
       define( "oboe", [], function () { return oboe; } );
+   } else if (typeof exports === 'object') {
+      module.exports = oboe;
    } else {
       window.oboe = oboe;
    }


### PR DESCRIPTION
This PR is to help better support browserify. I found the oboe-node.js did not work when bundled with browserify. The oboe-browser.js worked with adding the commonjs exports, and making sure that browserify uses the oboe-browser.js  build.
