### PR TITLE
Don't stream unsuccessful requests.

### DIFF
--- a/src/streamingHttp.browser.js
+++ b/src/streamingHttp.browser.js
@@ -49,7 +49,7 @@ function streamingHttp(oboeBus, xhr, method, url, data, headers, withCredentials
     */
    function handleProgress() {
 
-     if (String(xhr.status)[0] == 2) {
+     if (String(xhr.status)[0] === '2') {
        
         var textSoFar = xhr.responseText,
             newText = textSoFar.substr(numberOfCharsAlreadyGivenToCallback);

--- a/src/streamingHttp.browser.js
+++ b/src/streamingHttp.browser.js
@@ -3,13 +3,13 @@ function httpTransport(){
 }
 
 /**
- * A wrapper around the browser XmlHttpRequest object that raises an 
+ * A wrapper around the browser XmlHttpRequest object that raises an
  * event whenever a new part of the response is available.
- * 
- * In older browsers progressive reading is impossible so all the 
+ *
+ * In older browsers progressive reading is impossible so all the
  * content is given in a single call. For newer ones several events
  * should be raised, allowing progressive interpretation of the response.
- *      
+ *
  * @param {Function} oboeBus an event bus local to this Oboe instance
  * @param {XMLHttpRequest} xhr the xhr to use as the transport. Under normal
  *          operation, will have been created using httpTransport() above
@@ -21,61 +21,63 @@ function httpTransport(){
  * @param {Object} [headers] the http request headers to send
  * @param {boolean} withCredentials the XHR withCredentials property will be
  *    set to this value
- */  
+ */
 function streamingHttp(oboeBus, xhr, method, url, data, headers, withCredentials) {
-           
+
    "use strict";
-   
+
    var emitStreamData = oboeBus(STREAM_DATA).emit,
        emitFail       = oboeBus(FAIL_EVENT).emit,
        numberOfCharsAlreadyGivenToCallback = 0,
        stillToSendStartEvent = true;
 
-   // When an ABORTING message is put on the event bus abort 
-   // the ajax request         
+   // When an ABORTING message is put on the event bus abort
+   // the ajax request
    oboeBus( ABORTING ).on( function(){
-  
-      // if we keep the onreadystatechange while aborting the XHR gives 
+
+      // if we keep the onreadystatechange while aborting the XHR gives
       // a callback like a successful call so first remove this listener
       // by assigning null:
       xhr.onreadystatechange = null;
-            
+
       xhr.abort();
    });
 
-   /** 
+   /**
     * Handle input from the underlying xhr: either a state change,
     * the progress event or the request being complete.
     */
    function handleProgress() {
-                        
-      var textSoFar = xhr.responseText,
-          newText = textSoFar.substr(numberOfCharsAlreadyGivenToCallback);
-      
-      
-      /* Raise the event for new text.
-      
-         On older browsers, the new text is the whole response. 
-         On newer/better ones, the fragment part that we got since 
-         last progress. */
-         
-      if( newText ) {
-         emitStreamData( newText );
-      } 
 
-      numberOfCharsAlreadyGivenToCallback = len(textSoFar);
+     if (String(xhr.status)[0] == 2) {
+       
+        var textSoFar = xhr.responseText,
+            newText = textSoFar.substr(numberOfCharsAlreadyGivenToCallback);
+
+        /* Raise the event for new text.
+
+           On older browsers, the new text is the whole response.
+           On newer/better ones, the fragment part that we got since
+           last progress. */
+
+        if( newText ) {
+           emitStreamData( newText );
+        }
+
+        numberOfCharsAlreadyGivenToCallback = len(textSoFar);
+      }
    }
-   
-   
+
+
    if('onprogress' in xhr){  // detect browser support for progressive delivery
       xhr.onprogress = handleProgress;
    }
-      
+
    xhr.onreadystatechange = function() {
 
       function sendStartIfNotAlready() {
          // Internet Explorer is very unreliable as to when xhr.status etc can
-         // be read so has to be protected with try/catch and tried again on 
+         // be read so has to be protected with try/catch and tried again on
          // the next readyState if it fails
          try{
             stillToSendStartEvent && oboeBus( HTTP_START ).emit(
@@ -84,66 +86,66 @@ function streamingHttp(oboeBus, xhr, method, url, data, headers, withCredentials
             stillToSendStartEvent = false;
          } catch(e){/* do nothing, will try again on next readyState*/}
       }
-      
+
       switch( xhr.readyState ) {
-               
+
          case 2: // HEADERS_RECEIVED
          case 3: // LOADING
             return sendStartIfNotAlready();
-            
+
          case 4: // DONE
             sendStartIfNotAlready(); // if xhr.status hasn't been available yet, it must be NOW, huh IE?
-            
+
             // is this a 2xx http code?
             var successful = String(xhr.status)[0] == 2;
-            
+
             if( successful ) {
                // In Chrome 29 (not 28) no onprogress is emitted when a response
                // is complete before the onload. We need to always do handleInput
                // in case we get the load but have not had a final progress event.
                // This looks like a bug and may change in future but let's take
-               // the safest approach and assume we might not have received a 
+               // the safest approach and assume we might not have received a
                // progress event for each part of the response
                handleProgress();
-               
+
                oboeBus(STREAM_END).emit();
             } else {
 
                emitFail( errorReport(
-                  xhr.status, 
+                  xhr.status,
                   xhr.responseText
                ));
             }
       }
    };
-   
+
    try{
-   
+
       xhr.open(method, url, true);
-   
+
       for( var headerName in headers ){
          xhr.setRequestHeader(headerName, headers[headerName]);
       }
-      
+
       if( !isCrossOrigin(window.location, parseUrlOrigin(url)) ) {
          xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
       }
 
       xhr.withCredentials = withCredentials;
-      
+
       xhr.send(data);
-      
+
    } catch( e ) {
-      
+
       // To keep a consistent interface with Node, we can't emit an event here.
       // Node's streaming http adaptor receives the error as an asynchronous
       // event rather than as an exception. If we emitted now, the Oboe user
       // has had no chance to add a .fail listener so there is no way
       // the event could be useful. For both these reasons defer the
-      // firing to the next JS frame.  
+      // firing to the next JS frame.
       window.setTimeout(
          partialComplete(emitFail, errorReport(undefined, undefined, e))
       ,  0
       );
-   }            
+   }
 }


### PR DESCRIPTION
 We have no data extraction interest in them.

It's nasty too that if I have a failed request and I'm looking to handle it with a .fail,
then I'm getting the parsed error response (without status code) back in the .done callback.

Which is even more trouble that the done is fired before fail, so I don't even have a chance,
to abort the request because I know it failed. This seems like a resonable limitation to me,
that we limit the streaming to successful requests.

Oh, my editor stripped out a nice amount of whitespaces.
The only real change is to `handleProgress`, added an if clause to check `xhr.status`.
Thats it!
