### PR TITLE
change grunt's node-build-run to node-build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -233,7 +233,7 @@ module.exports = function (grunt) {
          testNode:{
             files: FILES_TRIGGERING_KARMA,
             tasks:[ 
-               'node-build-run']
+               'node-build']
          },         
          
          restartStreamSourceAndRunTests:{


### PR DESCRIPTION
Addresses #93 for easier development :smiley: 

## How to test
- `$ grunt watch`
- Trigger any change, like add some whitespace to `src/instanceApi.js`

###### On master
- You should see the error mentioned in #93 

###### On this branch
- Build succeeds!