### PR TITLE
add index.js for npm link

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+var oboe = require('./dist/oboe-node');
+
+module.exports = oboe;


### PR DESCRIPTION
Adds `index.js` which is read when you use `npm link` to develop in another repo.
Fixes #96 

## How to test
###### Set up
- **Set up Oboe**  — From your oboe directory, run `$ npm link`
- **Get test repo** — In another directory, run

    ```
    $ git clone https://github.com/JuanCaicedo/streaming-architecture.git -b oboe-on-done --single-branch
    $ npm install
     ```
- **Set up link** — In test repo `$ npm link oboe`
 
###### Master 
- In Oboe, `$ grunt watch`
- In Oboe, in `src/instanceApi.js, ln 9` add `console.log('test message')`
- In test rep, run `$ node module2.js`
- You should see nothing in the terminal

###### This branch
- In Oboe, 

    ```
    $ git remote add juan https://github.com/JuanCaicedo/oboe.js.git
    $ git fetch juan
    $ git checkout juan/add-index-for-npm-link
    ```

- In test rep, run `$ node module2.js`
- You should see `test message` in the console!