### PR TITLE
fix(clarinet): empty keys

### DIFF
--- a/test/json/emptyKey.json
+++ b/test/json/emptyKey.json
@@ -1,0 +1,4 @@
+{
+  "myKey1": "myValue1",
+  "": "myValue2"
+}

--- a/test/specs/oboe.integration.spec.js
+++ b/test/specs/oboe.integration.spec.js
@@ -111,6 +111,22 @@
             });
          });
 
+         it('can read an empty key', function() {
+
+            var fileStream = fs.createReadStream('test/json/emptyKey.json');
+
+            oboe(fileStream)
+                .node('!.*', callbackSpy)
+                .done(whenDoneFn);
+
+            waitsFor(doneCalled, 'the request to have called done', ASYNC_TEST_TIMEOUT);
+
+            runs(function () {
+
+               expect( callbackSpy.calls.length ).toBe(2);
+            });
+         });
+
          it('doesnt get confused if a stream has a "url" property', function() {
             var fileStream = fs.createReadStream('test/json/firstTenNaturalNumbers.json');
             fileStream.url = 'http://howodd.com';


### PR DESCRIPTION
Fixed a bug in the forked clarinet module where empty keys were not
emitting the `SAX_KEY` event and resulting in an error being thrown. The
parser now uses `undefined` as the default value for a text node instead
of the empty string.

See #108 