### PR TITLE
Fix issue#146 

### DIFF
--- a/dist/oboe-browser.js
+++ b/dist/oboe-browser.js
@@ -2606,7 +2606,9 @@ function applyDefaults( passthrough, url, httpMethodName, body, headers, withCre
          // Default Content-Type to JSON unless given otherwise.
          headers['Content-Type'] = headers['Content-Type'] || 'application/json';
       }
-      headers['Content-Length'] = headers['Content-Length'] || body.length;
+       //Issue #146 (https://github.com/jimhigson/oboe.js/issues/146)
+      //see https://stackoverflow.com/a/7210840/3501729
+      //headers['Content-Length'] = headers['Content-Length'] || body.length;
    } else {
       body = null;
    }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -17,7 +17,9 @@ function applyDefaults( passthrough, url, httpMethodName, body, headers, withCre
          // Default Content-Type to JSON unless given otherwise.
          headers['Content-Type'] = headers['Content-Type'] || 'application/json';
       }
-      headers['Content-Length'] = headers['Content-Length'] || body.length;
+       //Issue #146 (https://github.com/jimhigson/oboe.js/issues/146)
+       //see https://stackoverflow.com/a/7210840/3501729
+      //headers['Content-Length'] = headers['Content-Length'] || body.length;
    } else {
       body = null;
    }


### PR DESCRIPTION
Fixed [Issue #146 ](https://github.com/jimhigson/oboe.js/issues/146). Header content-length should be set by browser.