### PR TITLE
feature(instanceApi): proposal for adding support for Promises

### DIFF
--- a/src/instanceApi.js
+++ b/src/instanceApi.js
@@ -236,6 +236,23 @@ function instanceApi (oboeBus, contentSource) {
     source: contentSource
   }
 
+  function unsupportedOperation () {
+    throw new Error('Native Promises are not available and no Promise Library, via oboe.Promise, has been provided. Promise API cannot be supported.')
+  }
+
+  if (oboe.Promise || (typeof Promise !== 'undefined' && Promise.toString().indexOf('[native code]') !== -1)) {
+    var promise = new (oboe.Promise || Promise)(function (resolve, reject) {
+      partialComplete(addForgettableCallback, rootNodeFinishedEvent)(resolve)
+      oboeBus(FAIL_EVENT).on(reject)
+    })
+
+    oboeApi.then = promise.then.bind(promise)
+    oboeApi.catch = promise.catch.bind(promise)
+  } else {
+    oboeApi.then = unsupportedOperation
+    oboeApi.catch = unsupportedOperation
+  }
+
   return oboeApi
 }
 


### PR DESCRIPTION
Proposal for adding Promise API support #75 

`then` would be called as per `done`
`catch` called as per `fail`

Both done and fail will still also be called.

This does not add any external dependencies. A user could provide their own libarary via oboe.Promise or rely on native promises. Similar approach taken in [es6-promisify](https://www.npmjs.com/package/es6-promisify).

If no promise library is available calling `then` or `catch` will throw a (rather wordy) error so we only. This means that the error is only throw if someone tries to use `then` and `catch`. Another option could by just not to add the methods and let someone look up the docs.

Example:

```javascript
oboe('some/json/url')
  .node('result.*', (node) => {
    // your code here
  }).then((result) => {
    console.log(result);
  }).catch((err) => {
    console.error(err)
  })
```

Will write tests if you think its a reasonable approach.