### PR TITLE
Feature/use fetch api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ node_js:
 
 jobs: 
   include:
-    - stage: heap
+    - stage: chrome-based-tests
       node_js: 9
       before_install:
         - npm i puppeteer
       script: npm run test-heap
+      script: npm run test-fetch
+      

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -211,6 +211,15 @@ module.exports = function (grunt) {
     autoStartBrowsers.push('PhantomJS')
   })
 
+  grunt.registerTask('headless-chrome-mode', function () {
+    if (!process.env.CHROME_BIN) {
+      process.env.CHROME_BIN = require('puppeteer').executablePath()
+    }
+
+    autoStartBrowsers.length = 0
+    autoStartBrowsers.push('ChromeHeadless')
+  })
+
   grunt.registerTask('test-start-server', [
     'karma:persist'
   ])

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist-sizes": "node ./node_modules/grunt-cli/bin/grunt dist-sizes",
     "webpack": "webpack",
     "standard": "standard",
-    "test-heap": "node ./node_modules/grunt-cli/bin/grunt start-stream-source browser-build karma:single-heap"
+    "test-heap": "node ./node_modules/grunt-cli/bin/grunt start-stream-source browser-build headless-chrome-mode karma:single-heap"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dist-sizes": "node ./node_modules/grunt-cli/bin/grunt dist-sizes",
     "webpack": "webpack",
     "standard": "standard",
-    "test-heap": "node ./node_modules/grunt-cli/bin/grunt start-stream-source browser-build headless-chrome-mode karma:single-heap"
+    "test-heap": "node ./node_modules/grunt-cli/bin/grunt start-stream-source browser-build headless-chrome-mode karma:single-heap",
+    "test-fetch": "node ./node_modules/grunt-cli/bin/grunt start-stream-source browser-build headless-chrome-mode karma:single-browser-http"
   },
   "repository": {
     "type": "git",
@@ -105,7 +106,12 @@
     "globals": [
       "Platform",
       "crossDomainUrl",
-      "XMLHttpRequest"
+      "XMLHttpRequest",
+      "fetch",
+      "self",
+      "Headers",
+      "TextDecoder",
+      "Uint8Array"
     ]
   }
 }

--- a/src/streamingHttp.browser.js
+++ b/src/streamingHttp.browser.js
@@ -1,11 +1,12 @@
-import { isCrossOrigin, parseUrlOrigin } from './detectCrossOrigin.browser'
-import { STREAM_DATA, FAIL_EVENT, HTTP_START, STREAM_END, ABORTING, errorReport } from './events'
-import { len } from './util'
-import { parseResponseHeaders } from './parseResponseHeaders.browser'
-import { partialComplete } from './functional'
+import { fetchTransport, isFetchAvailable, streamingFetch } from './streamingHttp.fetch.browser'
+import { xhrTransport, streamingXhr } from './streamingHttp.xhr.browser'
 
 function httpTransport () {
-  return new XMLHttpRequest()
+  if (isFetchAvailable()) {
+    return fetchTransport()
+  }
+
+  return xhrTransport()
 }
 
 /**
@@ -28,121 +29,6 @@ function httpTransport () {
  * @param {boolean} withCredentials the XHR withCredentials property will be
  *    set to this value
  */
-function streamingHttp (oboeBus, xhr, method, url, data, headers, withCredentials) {
-  'use strict'
-
-  var emitStreamData = oboeBus(STREAM_DATA).emit
-  var emitFail = oboeBus(FAIL_EVENT).emit
-  var numberOfCharsAlreadyGivenToCallback = 0
-  var stillToSendStartEvent = true
-
-  // When an ABORTING message is put on the event bus abort
-  // the ajax request
-  oboeBus(ABORTING).on(function () {
-    // if we keep the onreadystatechange while aborting the XHR gives
-    // a callback like a successful call so first remove this listener
-    // by assigning null:
-    xhr.onreadystatechange = null
-
-    xhr.abort()
-  })
-
-  /**
-    * Handle input from the underlying xhr: either a state change,
-    * the progress event or the request being complete.
-    */
-  function handleProgress () {
-    if (String(xhr.status)[0] === '2') {
-      var textSoFar = xhr.responseText
-      var newText = (' ' + textSoFar.substr(numberOfCharsAlreadyGivenToCallback)).substr(1)
-
-      /* Raise the event for new text.
-
-       On older browsers, the new text is the whole response.
-       On newer/better ones, the fragment part that we got since
-       last progress. */
-
-      if (newText) {
-        emitStreamData(newText)
-      }
-
-      numberOfCharsAlreadyGivenToCallback = len(textSoFar)
-    }
-  }
-
-  if ('onprogress' in xhr) { // detect browser support for progressive delivery
-    xhr.onprogress = handleProgress
-  }
-
-  function sendStartIfNotAlready (xhr) {
-    // Internet Explorer is very unreliable as to when xhr.status etc can
-    // be read so has to be protected with try/catch and tried again on
-    // the next readyState if it fails
-    try {
-      stillToSendStartEvent && oboeBus(HTTP_START).emit(
-        xhr.status,
-        parseResponseHeaders(xhr.getAllResponseHeaders()))
-      stillToSendStartEvent = false
-    } catch (e) { /* do nothing, will try again on next readyState */ }
-  }
-
-  xhr.onreadystatechange = function () {
-    switch (xhr.readyState) {
-      case 2: // HEADERS_RECEIVED
-      case 3: // LOADING
-        return sendStartIfNotAlready(xhr)
-
-      case 4: // DONE
-        sendStartIfNotAlready(xhr) // if xhr.status hasn't been available yet, it must be NOW, huh IE?
-
-        // is this a 2xx http code?
-        var successful = String(xhr.status)[0] === '2'
-
-        if (successful) {
-          // In Chrome 29 (not 28) no onprogress is emitted when a response
-          // is complete before the onload. We need to always do handleInput
-          // in case we get the load but have not had a final progress event.
-          // This looks like a bug and may change in future but let's take
-          // the safest approach and assume we might not have received a
-          // progress event for each part of the response
-          handleProgress()
-
-          oboeBus(STREAM_END).emit()
-        } else {
-          emitFail(errorReport(
-            xhr.status,
-            xhr.responseText
-          ))
-        }
-    }
-  }
-
-  try {
-    xhr.open(method, url, true)
-
-    for (var headerName in headers) {
-      xhr.setRequestHeader(headerName, headers[headerName])
-    }
-
-    if (!isCrossOrigin(window.location, parseUrlOrigin(url))) {
-      xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
-    }
-
-    xhr.withCredentials = withCredentials
-
-    xhr.send(data)
-  } catch (e) {
-    // To keep a consistent interface with Node, we can't emit an event here.
-    // Node's streaming http adaptor receives the error as an asynchronous
-    // event rather than as an exception. If we emitted now, the Oboe user
-    // has had no chance to add a .fail listener so there is no way
-    // the event could be useful. For both these reasons defer the
-    // firing to the next JS frame.
-    window.setTimeout(
-      partialComplete(emitFail, errorReport(undefined, undefined, e))
-      , 0
-    )
-  }
-}
+var streamingHttp = isFetchAvailable() ? streamingFetch : streamingXhr
 
 export { httpTransport, streamingHttp }

--- a/src/streamingHttp.fetch.browser.js
+++ b/src/streamingHttp.fetch.browser.js
@@ -1,0 +1,104 @@
+import { STREAM_DATA, FAIL_EVENT, STREAM_END, HTTP_START, ABORTING, errorReport } from './events'
+import { isCrossOrigin, parseUrlOrigin } from './detectCrossOrigin.browser'
+
+function fetchTransport () {
+  return fetch
+}
+
+/**
+ * A wrapper around the browser XmlHttpRequest object that raises an
+ * event whenever a new part of the response is available.
+ *
+ * In older browsers progressive reading is impossible so all the
+ * content is given in a single call. For newer ones several events
+ * should be raised, allowing progressive interpretation of the response.
+ *
+ * @param {Function} oboeBus an event bus local to this Oboe instance
+ * @param {Function} fetch the browser fetch api to use as the transport. Under normal
+ *          operation, will have been created using httpTransport() above
+ *          but for tests a stub can be provided instead.
+ * @param {String} method one of 'GET' 'POST' 'PUT' 'PATCH' 'DELETE'
+ * @param {String} url the url to make a request to
+ * @param {String|Null} data some content to be sent with the request.
+ *                      Only valid if method is POST or PUT.
+ * @param {Object} [headers] the http request headers to send
+ * @param {boolean} withCredentials the XHR withCredentials property will be
+ *    set to this value
+ */
+function streamingFetch (oboeBus, fetch, method, url, data, headers, withCredentials) {
+  'use strict'
+
+  var decoder = new TextDecoder()
+
+  var featchHeaders = headers ? new Headers(headers) : new Headers()
+
+  if (!isCrossOrigin(window.location, parseUrlOrigin(url))) {
+    featchHeaders.append('X-Requested-With', 'XMLHttpRequest')
+  }
+
+  fetch(url, {
+    method: method,
+    body: data,
+    headers: featchHeaders,
+    credentials: withCredentials ? 'include' : 'same-origin'
+  }).then(function (response) {
+    var responseHeaders = getHeaders({}, response.headers, response.headers.keys())
+
+    oboeBus(HTTP_START).emit(
+      response.status,
+      responseHeaders
+    )
+
+    var reader = response.body.getReader()
+
+    oboeBus(ABORTING).on(function () {
+      reader.cancel()
+    })
+
+    if (response.ok) {
+      stream(oboeBus, reader, decoder)
+    } else {
+      oboeBus(FAIL_EVENT).emit(errorReport(
+        response.status,
+        response.statusText
+      ))
+    }
+  }).catch(function (error) {
+    oboeBus(FAIL_EVENT).emit(errorReport(
+      undefined,
+      error
+    ))
+  })
+}
+
+function getHeaders (memo, headers, keys) {
+  var key = keys.next()
+  if (key.done) {
+    return memo
+  } else {
+    memo[key.value] = headers.get(key.value)
+    return getHeaders(memo, headers, keys)
+  }
+}
+
+function stream (oboeBus, reader, decoder) {
+  reader.read().then(function (result) {
+    var chunk = decoder.decode(result.value || new Uint8Array(), {
+      stream: !result.done
+    })
+
+    oboeBus(STREAM_DATA).emit(chunk)
+
+    if (result.done) {
+      oboeBus(STREAM_END).emit()
+    } else {
+      stream(oboeBus, reader, decoder)
+    }
+  })
+}
+
+function isFetchAvailable () {
+  return !!window.fetch
+}
+
+export { fetchTransport, streamingFetch, isFetchAvailable }

--- a/src/streamingHttp.xhr.browser.js
+++ b/src/streamingHttp.xhr.browser.js
@@ -1,0 +1,148 @@
+import { isCrossOrigin, parseUrlOrigin } from './detectCrossOrigin.browser'
+import { STREAM_DATA, FAIL_EVENT, HTTP_START, STREAM_END, ABORTING, errorReport } from './events'
+import { len } from './util'
+import { parseResponseHeaders } from './parseResponseHeaders.browser'
+import { partialComplete } from './functional'
+
+function xhrTransport () {
+  return new XMLHttpRequest()
+}
+
+/**
+ * A wrapper around the browser XmlHttpRequest object that raises an
+ * event whenever a new part of the response is available.
+ *
+ * In older browsers progressive reading is impossible so all the
+ * content is given in a single call. For newer ones several events
+ * should be raised, allowing progressive interpretation of the response.
+ *
+ * @param {Function} oboeBus an event bus local to this Oboe instance
+ * @param {XMLHttpRequest} xhr the xhr to use as the transport. Under normal
+ *          operation, will have been created using httpTransport() above
+ *          but for tests a stub can be provided instead.
+ * @param {String} method one of 'GET' 'POST' 'PUT' 'PATCH' 'DELETE'
+ * @param {String} url the url to make a request to
+ * @param {String|Null} data some content to be sent with the request.
+ *                      Only valid if method is POST or PUT.
+ * @param {Object} [headers] the http request headers to send
+ * @param {boolean} withCredentials the XHR withCredentials property will be
+ *    set to this value
+ */
+function streamingXhr (oboeBus, xhr, method, url, data, headers, withCredentials) {
+  'use strict'
+
+  var emitStreamData = oboeBus(STREAM_DATA).emit
+  var emitFail = oboeBus(FAIL_EVENT).emit
+  var numberOfCharsAlreadyGivenToCallback = 0
+  var stillToSendStartEvent = true
+
+  // When an ABORTING message is put on the event bus abort
+  // the ajax request
+  oboeBus(ABORTING).on(function () {
+    // if we keep the onreadystatechange while aborting the XHR gives
+    // a callback like a successful call so first remove this listener
+    // by assigning null:
+    xhr.onreadystatechange = null
+
+    xhr.abort()
+  })
+
+  /**
+    * Handle input from the underlying xhr: either a state change,
+    * the progress event or the request being complete.
+    */
+  function handleProgress () {
+    if (String(xhr.status)[0] === '2') {
+      var textSoFar = xhr.responseText
+      var newText = (' ' + textSoFar.substr(numberOfCharsAlreadyGivenToCallback)).substr(1)
+
+      /* Raise the event for new text.
+
+       On older browsers, the new text is the whole response.
+       On newer/better ones, the fragment part that we got since
+       last progress. */
+
+      if (newText) {
+        emitStreamData(newText)
+      }
+
+      numberOfCharsAlreadyGivenToCallback = len(textSoFar)
+    }
+  }
+
+  if ('onprogress' in xhr) { // detect browser support for progressive delivery
+    xhr.onprogress = handleProgress
+  }
+
+  function sendStartIfNotAlready (xhr) {
+    // Internet Explorer is very unreliable as to when xhr.status etc can
+    // be read so has to be protected with try/catch and tried again on
+    // the next readyState if it fails
+    try {
+      stillToSendStartEvent && oboeBus(HTTP_START).emit(
+        xhr.status,
+        parseResponseHeaders(xhr.getAllResponseHeaders()))
+      stillToSendStartEvent = false
+    } catch (e) { /* do nothing, will try again on next readyState */ }
+  }
+
+  xhr.onreadystatechange = function () {
+    switch (xhr.readyState) {
+      case 2: // HEADERS_RECEIVED
+      case 3: // LOADING
+        return sendStartIfNotAlready(xhr)
+
+      case 4: // DONE
+        sendStartIfNotAlready(xhr) // if xhr.status hasn't been available yet, it must be NOW, huh IE?
+
+        // is this a 2xx http code?
+        var successful = String(xhr.status)[0] === '2'
+
+        if (successful) {
+          // In Chrome 29 (not 28) no onprogress is emitted when a response
+          // is complete before the onload. We need to always do handleInput
+          // in case we get the load but have not had a final progress event.
+          // This looks like a bug and may change in future but let's take
+          // the safest approach and assume we might not have received a
+          // progress event for each part of the response
+          handleProgress()
+
+          oboeBus(STREAM_END).emit()
+        } else {
+          emitFail(errorReport(
+            xhr.status,
+            xhr.responseText
+          ))
+        }
+    }
+  }
+
+  try {
+    xhr.open(method, url, true)
+
+    for (var headerName in headers) {
+      xhr.setRequestHeader(headerName, headers[headerName])
+    }
+
+    if (!isCrossOrigin(window.location, parseUrlOrigin(url))) {
+      xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
+    }
+
+    xhr.withCredentials = withCredentials
+
+    xhr.send(data)
+  } catch (e) {
+    // To keep a consistent interface with Node, we can't emit an event here.
+    // Node's streaming http adaptor receives the error as an asynchronous
+    // event rather than as an exception. If we emitted now, the Oboe user
+    // has had no chance to add a .fail listener so there is no way
+    // the event could be useful. For both these reasons defer the
+    // firing to the next JS frame.
+    window.setTimeout(
+      partialComplete(emitFail, errorReport(undefined, undefined, e))
+      , 0
+    )
+  }
+}
+
+export { xhrTransport, streamingXhr }

--- a/test/heap.conf.js
+++ b/test/heap.conf.js
@@ -1,7 +1,3 @@
-if (!process.env.CHROME_BIN) {
-  process.env.CHROME_BIN = require('puppeteer').executablePath()
-}
-
 module.exports = function (config) {
   config.set({
     browsers: ['ChromeHeadlessMemory'],


### PR DESCRIPTION
A proposal on how we might support using the fetch-api.

No api changes. Should be backwards compatible, there are no broken tests. Current http streaming tests run with no failures using the fetch api.

Incomplete, testing would obviously need to be added and I'm sure there are plenty of scenarios missed.

Great improvement with regard to heap usage using fetch.

Look forward to your comments.