### PR TITLE
Dont set the Content-length by default, possibly a security risk

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -17,7 +17,6 @@ function applyDefaults (passthrough, url, httpMethodName, body, headers, withCre
       // Default Content-Type to JSON unless given otherwise.
       headers['Content-Type'] = headers['Content-Type'] || 'application/json'
     }
-    headers['Content-Length'] = headers['Content-Length'] || body.length
   } else {
     body = null
   }


### PR DESCRIPTION
This is header is set by the browser automatically
https://stackoverflow.com/questions/7210507/ajax-post-error-refused-to-set-unsafe-header-connection/7210840

If manually set it possibly will cause a security risk
https://stackoverflow.com/questions/2623963/webkit-refused-to-set-unsafe-header-content-length
https://www.w3.org/TR/2008/WD-XMLHttpRequest-20080415/#case-insensitive-match

Unless it is for compatibility for HTTP/1.0
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4