### PR TITLE
do not set Content-Length header

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -17,7 +17,6 @@ function applyDefaults (passthrough, url, httpMethodName, body, headers, withCre
       // Default Content-Type to JSON unless given otherwise.
       headers['Content-Type'] = headers['Content-Type'] || 'application/json'
     }
-    headers['Content-Length'] = headers['Content-Length'] || body.length
   } else {
     body = null
   }


### PR DESCRIPTION
Because #146 is still open and #181 went nowhere.

Run-time detection of Node.js vs browser use is really what is needed here, but oboe.js does not appear to do this anywhere else in the code.  There is an apparently stagnant `src/streamingHttp.browser` vs `src/streamingHttp.node.js` paradigm, but this is only leveraged in tests.  As well, there is a separate Webpack build process for the two, but this seems only to differ in the post-processing (minification), modularity (ES6 vs UMD/AMD/CJS/...) and naming of the files.